### PR TITLE
Moving to pygatt (and back to bluepy again) and further implement bulb-functions/improve communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,27 @@ Go to the lib folder (usually `/usr/local/lib/python3.4/dist-packages/bluepy-1.0
 
 ## Usage
 
-**Library needs root permissions to use Bluetooth features.**
+**Library needs elevated permissions to use Bluetooth features. You can either run as root (required for magicblueshell), or give `hcitool` special capabilities (see next section.)**
 
 If you run into problems during devices listing or connect, try to follow this procedure to ensure your Bluetooth interface works correctly : [How to use manually with Gatttool page](https://github.com/Betree/pyMagicBlue/wiki/How-to-use-manually-with-Gatttool)
+
+### Giving hcitool capabilities
+
+You can give `hcitool` capabilities by installing and using the libcap library/commands.
+
+* On most Debian systems, including Raspbian/Raspberry Pi
+
+```
+sudo apt-get install libcap2-bin
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `which hcitool`
+```
+
+* Fedora
+
+```
+sudo dnf install libcap
+sudo setcap 'cap_net_raw,cap_net_admin+eip' `which hcitool`
+```
 
 ### Using it as an API
 

--- a/magicblue/magicbluelib.py
+++ b/magicblue/magicbluelib.py
@@ -101,6 +101,14 @@ class MagicBlue:
         """
         return self._device is not None
 
+    def get_device_name(self):
+        """
+        :return: Device name
+        """
+        # somehow, we have to read the handle and cannot read the UUID
+        handle = self._device.get_handle(UUID_CHARACTERISTIC_DEVICE_NAME)
+        return self._device.char_read_handle(handle)
+
     def set_warm_light(self, intensity=1.0):
         """
         Equivalent of what they call the "Warm light" property in the app that

--- a/magicblue/magicbluelib.py
+++ b/magicblue/magicbluelib.py
@@ -87,10 +87,8 @@ class MagicBlue:
         """
         logger.debug("Connecting...")
 
-        addr_type = _figure_addr_type(self.mac_address, self.version)
-
         try:
-            connection = btle.Peripheral(self.mac_address, addr_type,
+            connection = btle.Peripheral(self.mac_address, self._addr_type,
                                          bluetooth_adapter_nr)
             self._connection = connection.withDelegate(self)
             self._subscribe_to_recv_characteristic()

--- a/magicblue/magicbluelib.py
+++ b/magicblue/magicbluelib.py
@@ -32,7 +32,7 @@ def connection_required(func):
     """
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        if not self._connection:
+        if self._connection is None:
             raise Exception("Not connected")
 
         return func(self, *args, **kwargs)
@@ -129,6 +129,10 @@ class MagicBlue:
             self.get_device_name()
         except btle.BTLEException:
             self.disconnect()
+            return False
+        except BrokenPipeError:
+            # bluepy-helper died
+            self._connection = None
             return False
 
         return True

--- a/magicblue/magicblueshell.py
+++ b/magicblue/magicblueshell.py
@@ -61,6 +61,9 @@ class MagicBlueShell:
             MagicBlueShell.Cmd('turn', self.cmd_turn, True,
                                help='Turn on / off the bulb',
                                params=['on|off']),
+            MagicBlueShell.Cmd('read', self.cmd_read, True,
+                               help='Read device_info/datetime from the bulb',
+                               params=['device_info|date_time']),
             MagicBlueShell.Cmd('exit', self.cmd_exit, False,
                                help='Exit the script')
         ]
@@ -156,6 +159,14 @@ class MagicBlueShell:
             self._magic_blue.turn_on()
         else:
             self._magic_blue.turn_off()
+
+    def cmd_read(self, *args):
+        if args[0][0] == 'device_info':
+            device_info = self._magic_blue.request_device_info()
+            logger.info('Received device_info: {}'.format(device_info))
+        elif args[0][0] == 'date_time':
+            datetime_ = self._magic_blue.request_date_time()
+            logger.info('Received datetime: {}'.format(datetime_))
 
     def cmd_set_color(self, *args):
         color = args[0][0]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     license='MIT',
     packages=['magicblue'],
     install_requires=[
-        'pygatt==3.1.1',
+        'bluepy==1.0.5',
         'webcolors'
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     license='MIT',
     packages=['magicblue'],
     install_requires=[
-        'bluepy',
+        'pygatt==3.1.1',
         'webcolors'
     ],
     include_package_data=True,


### PR DESCRIPTION
Following up on #17. Here is a pull request which moves `magicblue` to `pygatt` from `bluepy`, and further implements the protocol.

Unfortunately, I have (yet) seen no way to dynamically figure out the address type to use. The software does try to guess if no version is given, but your mileage may vary. Maybe we can detect it from the bulb-address? Please, let me know the versions and mac addresses of your bulb(s).

Also, scanning for bulbs is now slightly altered. `pygatt` reports all found devices at once _after_ scanning. `bluepy` uses a callback which is called _during_ scanning. In the new method of scanning, it might look scanning has stalled. Therefore, I have shortened the scanning-time to 10 seconds.

Please, feel free to provide any feedback. And, of course, do test this on your own bulb(s)! For my V10 bulbs all implemented functions work.