### PR TITLE
Allow using multiple bulbs at the same time with magicblueshell

### DIFF
--- a/magicblue/magicbluelib.py
+++ b/magicblue/magicbluelib.py
@@ -29,7 +29,7 @@ UUID_CHARACTERISTIC_DEVICE_NAME = btle.UUID('2a00')
 
 def connection_required(func):
     """Raise an exception before calling the actual function if the device is
-    not connection.
+    not connected.
     """
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
@@ -50,9 +50,9 @@ def _figure_addr_type(mac_address=None, version=None, addr_type=None):
     if version == 9 or version == 10:
         return btle.ADDR_TYPE_PUBLIC
 
-    if version == 8:
+    if version == 7 or version == 8:
         return btle.ADDR_TYPE_RANDOM
-    
+
     # try using mac_address
     if mac_address is not None:
         mac_address_num = int(mac_address.replace(':', ''), 16)


### PR DESCRIPTION
* `connect` can now be called multiple time with all the bulbs you want to connect to. Commands are then dispatched on every bulb one at a time
* `connect` now accepts bulb version as an optional argument, allowing to connect to multiple bulbs with different versions at the same time
* Cleaned some stuff in lib code

#27